### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   # ログインしていないユーザーはログインページに促す
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, only: [:new, :create]
 
   # 重複処理をまとめる
   # before_action :set_item, only: [:show, :edit, :update, :destroy]
@@ -41,9 +41,9 @@ class ItemsController < ApplicationController
   #   end
   # end
 
-  # def show
-  #   @item = Item.find(params[:id])
-  # end
+  def show
+    @item = Item.find(params[:id])
+  end
 
   # def destroy
   #   # ログインしているユーザーと同一であればデータを削除する

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品データがある場合は、eachメソッドで一覧表示する %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
         <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
           <%# 商品が売れていればsold outを表示(.present?でも可) %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,114 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.title %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag @item.image.variant(resize: '500x500'),class:"item-box-img" %>
+  
+      <%# 商品が売れている場合は、sold outを表示 %>
+      <%# <% if @item.order != nil %>
+      <%# <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+      <% end %> 
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        <%= @item.price %>円
+      </span>
+      <span class="item-postage">
+        <%= @item.shipping_cost.name %>
+      </span>
+    </div>
+
+  <%# ログイン中であれば表示 %>
+  <% if user_signed_in? %> 
+    <%# 出品者かつ未購入品であれば、編集・削除を表示 %>
+    <% if current_user.id == @item.user_id %> 
+      <%= link_to '商品の編集',"#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+
+      <%# 未購入品でない場合には、売り切れを表示 %>
+      <%# elsif @item.order.present? %>
+      
+      <% else %>
+      <%# 出品者以外かつ未購入品であれば、購入画面を表示 %>
+      <%= link_to '購入画面に進む', "#", class:"item-red-btn"%>
+      <% end %>
+  <% end %>
+
+    <div class="item-explain-box">
+      <span><%= @item.text %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @item.category.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @item.sales_status.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -18,7 +18,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%= @item.price %>円
+        ¥ <%= @item.price %>円
       </span>
       <span class="item-postage">
         <%= @item.shipping_cost.name %>


### PR DESCRIPTION
#What
商品詳細表示機能の実装

#Why
ユーザーが商品の詳細を確認できるようにするため

①ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/3dae9c318775bf56274aa20492d8e8bc

②ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/6b22c1d89419513d7a49869db588b169

③ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画
現段階では商品購入機能を実装していないのでキャプチャなし

④ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/8e0d8b616bdc72381020bfe0175767c3